### PR TITLE
exit 0 if there is no text to send

### DIFF
--- a/auto_report/__main__.py
+++ b/auto_report/__main__.py
@@ -80,4 +80,5 @@ def cli():
         response = webhook.send(text=f"morning stats\n```{text}```")
         logger.debug("Slack webhook response: %s", response)
         sys.exit(0)
-    sys.exit(1)
+
+    logger.warning("There is no text to send.")


### PR DESCRIPTION
This avoids exit with 1 and causing restart when there is no data to send (empty environment for example)

Signed-off-by: Riccardo piccoli <rpiccoli@redhat.com>