### PR TITLE
MGMT-15798: Upgrade to ubi9 base image in order to have patched glibc package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 RUN --mount=type=tmpfs,destination=/var/cache\
     --mount=type=tmpfs,destination=/root/.cache\


### PR DESCRIPTION
Upgrade to `ubi9` base image in order to have patched `glibc` package