### PR TITLE
KONFLUX-1611: Add labels, licenses & user to Dockerfile

### DIFF
--- a/.tekton/auto-report-saas-main-pull-request.yaml
+++ b/.tekton/auto-report-saas-main-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/auto-report-saas-main-push.yaml
+++ b/.tekton/auto-report-saas-main-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,23 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
+ARG release=main
+ARG version=latest
+
+LABEL com.redhat.component auto-report
+LABEL description "Automatically generates reports from OpenSearch data"
+LABEL summary "Automatically generates reports from OpenSearch data"
+LABEL io.k8s.description "Automatically generates reports from OpenSearch data"
+LABEL distribution-scope public
+LABEL name auto-report
+LABEL release ${release}
+LABEL version ${version}
+LABEL url https://github.com/openshift-assisted/auto-report
+LABEL vendor "Red Hat, Inc."
+LABEL maintainer "Red Hat"
+
+# License
+COPY LICENSE /licenses/
+
 RUN --mount=type=tmpfs,destination=/var/cache\
     --mount=type=tmpfs,destination=/root/.cache\
     --mount=type=cache,target=/var/cache/yum\
@@ -19,5 +37,7 @@ RUN --mount=type=tmpfs,destination=/root/.cache\
 
 COPY . ./
 RUN python3 -m pip install .
+
+USER 1001:1001
 
 ENTRYPOINT ["auto_report"]


### PR DESCRIPTION
* Add labels
* Add default user
* Add licenses under /licenses/ (dependencies licenses are not taken) 

Requirements come from https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#additional_resources and would prevent us from releasing an image (we have an exception for "based_on_ubi image")