### PR TITLE
MGMT-19126: Migrate auto-report to Konflux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=type=tmpfs,destination=/root/.cache\
     python3 -m pip install -r requirements.txt
 
 COPY . ./
-RUN python3 -m pip install .
+RUN python3 -m pip install . pip-licenses && pip-licenses -l -f json --output-file /licenses/licenses.json
 
 USER 1001:1001
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,9 +2,11 @@
 
 set -exu
 
-TAG=$(git rev-parse --short=7 HEAD)
+TAG=$(git rev-parse HEAD)
+SHORT_TAG=$(git rev-parse --short=7 HEAD)
 REPO="quay.io/app-sre/auto-report"
 export AUTO_REPORT_IMAGE="${REPO}:${TAG}"
+export AUTO_REPORT_IMAGE_SHORT_TAG="${REPO}:${SHORT_TAG}"
 export CONTAINER_BUILD_EXTRA_PARAMS="--no-cache"
 export DOCKER_BUILDKIT=1
 
@@ -13,6 +15,8 @@ make build-image
 DOCKER_CONF="$PWD/assisted/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.io
+docker tag "${AUTO_REPORT_IMAGE}" "${AUTO_REPORT_IMAGE_SHORT_TAG}"
 docker tag "${AUTO_REPORT_IMAGE}" "${REPO}:latest"
 docker --config="$DOCKER_CONF" push "${AUTO_REPORT_IMAGE}"
+docker --config="$DOCKER_CONF" push "${AUTO_REPORT_IMAGE_SHORT_TAG}"
 docker --config="$DOCKER_CONF" push "${REPO}:latest"


### PR DESCRIPTION
We want to change app-interface to deploy the images that Konflux builds and by default Konflux uses the full commit sha as the tag.
In order to avoid issues with telling app-interface to use the full commit sha, I am updating build_deploy.sh to push both the full sha and the short sha as image tags.
Also added licenses scraping.

Part of [MGMT-19126](https://issues.redhat.com//browse/MGMT-19126)